### PR TITLE
feat: Add a proxy handler to the http-server component

### DIFF
--- a/etc/http-server.api.md
+++ b/etc/http-server.api.md
@@ -57,6 +57,7 @@ export type HttpMetrics = keyof typeof metrics;
 // @public (undocumented)
 export type IHttpServerOptions = {
     cors?: CorsOptions;
+    proxyHandler?: (request: http.IncomingMessage, response: http.ServerResponse, next: () => void) => Promise<void>;
 } & ({
     https: https.ServerOptions;
 } | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,4 +31,5 @@ export type ServerComponents = {
  */
 export type IHttpServerOptions = {
   cors?: CorsOptions
+  proxyHandler?: (request: http.IncomingMessage, response: http.ServerResponse, next: () => void) => Promise<void>
 } & ({ https: https.ServerOptions } | { http: http.ServerOptions })


### PR DESCRIPTION
This PR adds an optional proxy handler method to the server component.

This change allows an external custom handler to be passed before executing the original one.